### PR TITLE
✨ Efficient changepoint filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,12 @@ ignore_index:
     Specifies a target value that is ignored and does not contribute to the metric calculation
 validate_args: bool indicating if input arguments and tensors should be validated for correctness.
     Set to ``False`` for faster computations.
-use_reference_implementation:
+changepoints_only:
+    Modify the exact curve to retain the relevant points only.
+reference_implementation:
     Fall back to the official MVTecAD implementation for the exact computation.
-kwargs: Additional keyword arguments, see :ref:`Metric kwargs` for more info.
+kwargs:
+    Additional keyword arguments, see :ref:`Metric kwargs` for more info.
 ```
 
 An ``update`` of the metric expects a three-dimensional ``preds`` tensor where the first dimension is the batch dimension (floats between zero and one; otherwise, the values are considered logits) and an equally shaped ``target`` tensor containing binary ground truth labels ({0,1} values).

--- a/notebooks/profile.ipynb
+++ b/notebooks/profile.ipynb
@@ -33,7 +33,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pyaupro._implementation import _per_region_overlap_update, _per_region_overlap_compute # noqa: F401"
+    "from pyaupro._implementation import _per_region_overlap_compute, _per_region_overlap_update"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyaupro"
-version = "0.1.5"
+version = "0.1.6"
 description = "Efficient per-region overlap (PRO) calculation implemented using torchmetrics."
 authors = [{ name = "David Muhr", email = "muhrdavid+github@gmail.com" }]
 readme = "README.md"
@@ -52,3 +52,11 @@ include = ["src/pyaupro/**/*.py"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/pyaupro"]
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "W", "I", "F", "NPY", "PERF", "UP", "FURB", "RUF"]
+fixable = ["ALL"]
+ignore = ["F401"]

--- a/src/pyaupro/__init__.py
+++ b/src/pyaupro/__init__.py
@@ -1,6 +1,6 @@
-from ._implementation import PerRegionOverlap as PerRegionOverlap
-from ._utilities import auc_compute as auc_compute
-from ._utilities import generate_random_data as generate_random_data
+from ._implementation import PerRegionOverlap
+from ._utilities import auc_compute, generate_random_data
+
 
 def get_version() -> str:
     """Return the package version or "unknown" if no version can be found."""

--- a/src/pyaupro/_reference.py
+++ b/src/pyaupro/_reference.py
@@ -1,10 +1,10 @@
-"""
-Code is taken from the official reference of the MVTec evaluation code 
-found at https://www.mvtec.com/company/research/datasets/mvtec-ad
+"""Code is taken from the official reference of the MVTec evaluation code
+found at https://www.mvtec.com/company/research/datasets/mvtec-ad.
 """
 
 import numpy as np
 from scipy.ndimage import label
+
 
 def compute_pro(anomaly_maps, ground_truth_maps):
     """Compute the PRO curve for a set of anomaly maps with corresponding ground
@@ -22,8 +22,8 @@ def compute_pro(anomaly_maps, ground_truth_maps):
     Returns:
         fprs: numpy array of false positive rates.
         pros: numpy array of corresponding PRO values.
-    """
 
+    """
     # print("Compute PRO curve...")
 
     # Structuring element for computing connected components.
@@ -37,7 +37,7 @@ def compute_pro(anomaly_maps, ground_truth_maps):
              anomaly_maps[0].shape[1])
     fp_changes = np.zeros(shape, dtype=np.uint32)
     assert shape[0] * shape[1] * shape[2] < np.iinfo(fp_changes.dtype).max, \
-        'Potential overflow when using np.cumsum(), consider using np.uint64.'
+        "Potential overflow when using np.cumsum(), consider using np.uint64."
 
     pro_changes = np.zeros(shape, dtype=np.float64)
 

--- a/src/pyaupro/_utilities.py
+++ b/src/pyaupro/_utilities.py
@@ -1,8 +1,10 @@
-import torch
-from torch import Tensor
-import numpy as np
-from scipy.ndimage import gaussian_filter
 from typing import Any
+
+import numpy as np
+import torch
+from scipy.ndimage import gaussian_filter
+from torch import Tensor
+
 
 def auc_compute(
         x: Tensor,
@@ -12,13 +14,13 @@ def auc_compute(
         descending: bool = False,
         reorder: bool = False,
         check: bool = True,
-        return_curve: bool = False
+        return_curve: bool = False,
     ) -> Tensor | tuple[Tensor, Tensor, Tensor]:
     """Compute area under the curve using the trapezoidal rule.
 
     Args:
         x:
-            Ascending (or descending if ``descending=True``) sorted vector if, 
+            Ascending (or descending if ``descending=True``) sorted vector if,
             otherwise ``reorder`` must be used.
         y:
             Vector of the same size as ``x``.
@@ -73,7 +75,7 @@ def generate_random_data(
         num_objects: int = 2,
         noise_level: float =0.25,
         return_numpy: bool = False,
-        seed: Any = None # dynamically validated in ``default_rng
+        seed: Any = None, # dynamically validated in ``default_rng
     ) -> tuple[Tensor, Tensor] | tuple[np.ndarray, np.ndarray]:
     """Generates random test data: binary masks and probabilistic predictions."""
     rng = np.random.default_rng(seed)
@@ -95,5 +97,5 @@ def generate_random_data(
 
     if return_numpy:
         return preds, masks
-    
+
     return torch.from_numpy(preds), torch.from_numpy(masks)

--- a/tests/test_pyaupro.py
+++ b/tests/test_pyaupro.py
@@ -1,21 +1,25 @@
 import pytest
 import torch
-from packaging.version import Version
-from pyaupro import PerRegionOverlap, auc_compute, generate_random_data, get_version
 from numpy.testing import assert_approx_equal
+from packaging.version import Version
+
+from pyaupro import PerRegionOverlap, auc_compute, generate_random_data, get_version
 
 # generate samples of unequal batch size to test if the updates are correctly
 # weighted and vary ``noise_level`` to generate batches of differing AUC.
 # additionally vary the number of objects for overlap calculation.
 noise_levels = [0.2, 0.4, 0.6]
 d0, d1, d2 = [generate_random_data(
-    seed=i + 1, batch_size=i + 1, num_objects=i + 2, noise_level=n
+    seed=i + 1, batch_size=i + 1, num_objects=i + 2, noise_level=n,
 ) for i, n in enumerate(noise_levels)]
 test_data = [[d0], [d1, d2], [d0, d1, d2]]
+bool_opts = [True, False]
 
+@pytest.mark.parametrize("changepoints", bool_opts)
 @pytest.mark.parametrize("data", test_data)
-def test_exact_computation(data):
-    metric = PerRegionOverlap(thresholds=None)
+def test_exact_computation(changepoints, data) -> None:
+    """Test basic properties of the exact implementation."""
+    metric = PerRegionOverlap(thresholds=None, changepoints_only=changepoints)
     for (preds, target) in data:
         metric.update(preds, target)
 
@@ -23,12 +27,15 @@ def test_exact_computation(data):
     assert isinstance(fpr, torch.Tensor)
     assert isinstance(pro, torch.Tensor)
     assert fpr.shape == pro.shape
-    assert torch.all(fpr >= 0) and torch.all(fpr <= 1)
-    assert torch.all(pro >= 0) and torch.all(pro <= 1)
+    assert torch.all(fpr >= 0)
+    assert torch.all(fpr <= 1)
+    assert torch.all(pro >= 0)
+    assert torch.all(pro <= 1)
 
 @pytest.mark.parametrize("data", test_data)
 @pytest.mark.parametrize("thresholds", [5, 10, [0.2, 0.4, 0.6, 0.8]])
-def test_approximated_computation(data, thresholds):
+def test_approximated_computation(data, thresholds) -> None:
+    """Test basic properties of the approximate implementation."""
     metric = PerRegionOverlap(thresholds=thresholds)
     for (preds, target) in data:
         metric.update(preds, target)
@@ -38,15 +45,19 @@ def test_approximated_computation(data, thresholds):
     assert isinstance(pro, torch.Tensor)
     n_thresh = len(thresholds) if isinstance(thresholds, list) else thresholds
     assert fpr.shape == pro.shape == (n_thresh,)
-    assert torch.all(fpr >= 0) and torch.all(fpr <= 1)
-    assert torch.all(pro >= 0) and torch.all(pro <= 1)
+    assert torch.all(fpr >= 0)
+    assert torch.all(fpr <= 1)
+    assert torch.all(pro >= 0)
+    assert torch.all(pro <= 1)
 
+@pytest.mark.parametrize("changepoints", bool_opts)
 @pytest.mark.parametrize("data", test_data)
 @pytest.mark.parametrize("thresholds", [100, torch.linspace(0, 1, 100)])
-def test_approx_auc_similar_to_exact_auc(data, thresholds):
-    metric_exact = PerRegionOverlap(thresholds=None)
+def test_approx_auc_similar_to_exact_auc(changepoints, data, thresholds) -> None:
+    """There should be no significant difference between the implementations."""
+    metric_exact = PerRegionOverlap(thresholds=None, changepoints_only=changepoints)
     metric_approx = PerRegionOverlap(thresholds=thresholds)
-    metric_reference = PerRegionOverlap(use_reference_implementation=True)
+    metric_reference = PerRegionOverlap(reference_implementation=True)
 
     for (preds, target) in data:
         metric_approx.update(preds, target)
@@ -56,9 +67,9 @@ def test_approx_auc_similar_to_exact_auc(data, thresholds):
     fpr_approx, pro_approx = metric_approx.compute()
     auc_approx = auc_compute(fpr_approx, pro_approx, reorder=True)
     fpr_exact, pro_exact = metric_exact.compute()
-    auc_exact = auc_compute(fpr_exact, pro_exact, reorder=True)    
+    auc_exact = auc_compute(fpr_exact, pro_exact, reorder=True)
     fpr_reference, pro_reference = metric_reference.compute()
-    auc_reference = auc_compute(fpr_reference, pro_reference, reorder=True)    
+    auc_reference = auc_compute(fpr_reference, pro_reference, reorder=True)
 
     # with a large enough number of thresholds, the values should be close
     assert_approx_equal(auc_approx, auc_reference, significant=2)
@@ -68,7 +79,8 @@ def test_approx_auc_similar_to_exact_auc(data, thresholds):
     # probably due to rounding errors.
     assert_approx_equal(auc_exact, auc_reference, significant=2)
 
-def test_invalid_inputs():
+def test_invalid_threshold_inputs() -> None:
+    """Invalid threshold input values should raise an error."""
     with pytest.raises(ValueError):
         PerRegionOverlap(thresholds=-1)
 
@@ -78,6 +90,6 @@ def test_invalid_inputs():
     with pytest.raises(ValueError):
         PerRegionOverlap(thresholds=[-0.1, 1.2])
 
-def test_version_readable():
-    # Raises if get_version returns an invalid version
+def test_version_readable() -> None:
+    """Raises if get_version returns an invalid version."""
     Version(get_version())

--- a/uv.lock
+++ b/uv.lock
@@ -439,11 +439,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.17.0"
+version = "3.18.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dc/9c/0b15fb47b464e1b663b1acd1253a062aa5feecb07d4e597daea542ebd2b5/filelock-3.17.0.tar.gz", hash = "sha256:ee4e77401ef576ebb38cd7f13b9b28893194acc20a8e68e18730ba9c0e54660e", size = 18027 }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/ec/00d68c4ddfedfe64159999e5f8a98fb8442729a63e2077eb9dcd89623d27/filelock-3.17.0-py3-none-any.whl", hash = "sha256:533dc2f7ba78dc2f0f531fc6c4940addf7b70a481e269a5a3b93be94ffbe8338", size = 16164 },
+    { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215 },
 ]
 
 [[package]]
@@ -1650,7 +1650,7 @@ wheels = [
 
 [[package]]
 name = "pyaupro"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },
@@ -2297,7 +2297,7 @@ wheels = [
 
 [[package]]
 name = "torchmetrics"
-version = "1.6.2"
+version = "1.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lightning-utilities" },
@@ -2305,9 +2305,9 @@ dependencies = [
     { name = "packaging" },
     { name = "torch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7f/88/92e1ebf38a613906b9044c137d4cc865928f76b98dd9b75d84339dab4f4e/torchmetrics-1.6.2.tar.gz", hash = "sha256:a3fa6372dbf01183d0f6fda2159e9526fb62818aa3630660909c290425f67df6", size = 544658 }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/30/2575bd8bbf2274dd117f591838c70916df98812874a32e3e91200b291cb2/torchmetrics-1.6.3.tar.gz", hash = "sha256:be59ffe9e9abf12ac12c3ac4383b2fc7731ad2bf3748ae1b06e8dea34e9f8a65", size = 544716 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/c3/4e87b5f6bbd9600e3fab42267f242e8d5c3a04749afd1b6735231a9511e9/torchmetrics-1.6.2-py3-none-any.whl", hash = "sha256:586b970aff33a2154bfb6ed4539a557e9a268b6dce408bbdef0fec99fef3c78b", size = 931620 },
+    { url = "https://files.pythonhosted.org/packages/81/68/80a2df3924f354e06e82cc030d86de9936057f74d8482109be3042a4f1d5/torchmetrics-1.6.3-py3-none-any.whl", hash = "sha256:034640d4e1c30b7d3488551b1ce3fc1f363070811e6b97b9cb6b60a9ec15e9f4", size = 931705 },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds a ``changepoints_only`` argument to ``PerRegionOverlap``, which is set to true by default. Using changepoint filtering only the relevant points are retained for the exact computation result. This is similar to the approach taken by the MVTecAD authors.

- A point is redundant if it has constant PRO both before and after.
- A point is redundant if it has constant FPR both before and after.