### PR TITLE
🐛 Fix special cases in area calculation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyaupro"
-version = "0.1.8"
+version = "0.1.9"
 description = "Efficient per-region overlap (PRO) calculation implemented using torchmetrics."
 authors = [{ name = "David Muhr", email = "muhrdavid+github@gmail.com" }]
 readme = "README.md"


### PR DESCRIPTION
This PR solves a bug in ``auc_compute``, which occured if there are large gaps in the predicted curve and no point is close to a chosen integration limit, in which case the curve might be nearly "empty". The solution is the append or prepend the limit value directly to ensure that the curve is always fully filled.